### PR TITLE
fix: change active suggest background in light theme

### DIFF
--- a/themes/1984-light-color-theme.json
+++ b/themes/1984-light-color-theme.json
@@ -27,7 +27,7 @@
     "editorHoverWidget.border": "#19152c",
     "editorSuggestWidget.background": "#d9dbf0",
     "editorSuggestWidget.border": "#19152c",
-    "editorSuggestWidget.selectedBackground": "#d9dbf0",
+    "editorSuggestWidget.selectedBackground": "#46beff6b",
     "editorWidget.background": "#d9dbf0",
     "input.background": "#d4d5e9",
     "input.border": "#a8b6ca",


### PR DESCRIPTION
Use the same `selectedBackground` as in list `activeSelectionBackground`

<img width="704" alt="Screen Shot 2019-11-22 at 3 19 04 PM" src="https://user-images.githubusercontent.com/1840423/69425297-c35b6600-0d3b-11ea-9bb2-6838f78b630c.png">
